### PR TITLE
Fix `flake8` issue in pre-commit hooks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,0 @@
-[flake8]
-ignore = D100,D104
-# D100:  D100 Missing docstring in public module
-# D104: Missing docstring in public package
-exclude = .git,.tox,build,dist,__pycache__
-max_line_length = 120
-filename = *.py
-ban-relative-imports = true


### PR DESCRIPTION
## Bug fixes

<!-- Please give section if this PR does not fix any bugs -->

-   Deletes `tox.ini` s.t. the pre-commit hooks properly work with the `.flak8` specifications.

## Related issues

<!-- Please list related issues. If none exist, open one and reference it here. -->

Closes #25.
